### PR TITLE
외부 API 호출의 안정성과 성능을 개선하기 위해 DB를 이용한 캐싱 및 일일 호출 횟수 제한 기능을 구현.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.testcontainers:postgresql:1.20.0")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/jhinslog/buswhich/BusWhichApplication.java
+++ b/src/main/java/com/jhinslog/buswhich/BusWhichApplication.java
@@ -2,10 +2,10 @@ package com.jhinslog.buswhich;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
+@SpringBootApplication
+@EnableScheduling
 public class BusWhichApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/jhinslog/buswhich/domain/cache/CachedStationArrival.java
+++ b/src/main/java/com/jhinslog/buswhich/domain/cache/CachedStationArrival.java
@@ -1,0 +1,37 @@
+package com.jhinslog.buswhich.domain.cache; // 패키지 변경
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cached_station_arrivals")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CachedStationArrival {
+
+    @Id
+    @Column(name = "station_id", length = 50)
+    private String stationId;
+
+    @Lob
+    @Column(name = "arrival_data_json", columnDefinition = "TEXT")
+    private String arrivalDataJson;
+
+    @Column(name = "last_api_call_time")
+    private LocalDateTime lastApiCallTime;
+
+    @Column(name = "cache_expiry_time")
+    private LocalDateTime cacheExpiryTime;
+
+    public CachedStationArrival(String stationId, String arrivalDataJson, LocalDateTime lastApiCallTime, LocalDateTime cacheExpiryTime) {
+        this.stationId = stationId;
+        this.arrivalDataJson = arrivalDataJson;
+        this.lastApiCallTime = lastApiCallTime;
+        this.cacheExpiryTime = cacheExpiryTime;
+    }
+}

--- a/src/main/java/com/jhinslog/buswhich/dto/response/SpecificStationArrivalDto.java
+++ b/src/main/java/com/jhinslog/buswhich/dto/response/SpecificStationArrivalDto.java
@@ -1,11 +1,9 @@
 package com.jhinslog.buswhich.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,6 +13,7 @@ public class SpecificStationArrivalDto {
     private String arsId;               // 정류소 번호 (arsId)
     private String stationOrder;        // 해당 노선에서의 정류소 순번 (staOrd)
     private String direction;           // 진행 방향 (dir)
+    private String routeName;           // 노선명
 
     private String firstArrivalMsg;     // 첫 번째 버스 도착 메시지 (arrmsg1)
     private Integer firstRemainingSec;  // 첫 번째 버스 남은 시간(초) (traTime1 또는 exps1 등에서 변환)

--- a/src/main/java/com/jhinslog/buswhich/repository/cache/CachedStationArrivalRepository.java
+++ b/src/main/java/com/jhinslog/buswhich/repository/cache/CachedStationArrivalRepository.java
@@ -1,0 +1,12 @@
+package com.jhinslog.buswhich.repository.cache;
+
+import com.jhinslog.buswhich.domain.cache.CachedStationArrival;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CachedStationArrivalRepository extends JpaRepository<CachedStationArrival, String> {
+    Optional<CachedStationArrival> findByStationId(String stationId);
+}

--- a/src/main/java/com/jhinslog/buswhich/scheduler/ApiRateLimitedCacheRefreshScheduler.java
+++ b/src/main/java/com/jhinslog/buswhich/scheduler/ApiRateLimitedCacheRefreshScheduler.java
@@ -1,0 +1,92 @@
+package com.jhinslog.buswhich.scheduler;
+
+import com.jhinslog.buswhich.service.BusArrivalCacheService;
+import com.jhinslog.buswhich.websocket.ArrivalBusInfoHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class ApiRateLimitedCacheRefreshScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiRateLimitedCacheRefreshScheduler.class);
+
+    private final BusArrivalCacheService cacheService;
+    private final ArrivalBusInfoHandler arrivalBusInfoHandler;
+    // ApiCallManager는 BusArrivalCacheService -> SeoulBusArrivalServiceImpl을 통해 간접적으로 사용됩니다.
+
+    // 하루에 API를 통해 캐시를 갱신할 수 있는 최대 정류소 수 (매우 보수적인 예시)
+    // 실제 SeoulBusArrivalServiceImpl에서 ApiCallManager가 호출을 제어하므로,
+    // 이 스케줄러의 역할은 "어떤 정류소의 캐시를 갱신 시도할 것인가"에 더 초점.
+    private static final int MAX_STATIONS_TO_ATTEMPT_REFRESH_PER_DAY = 100; // 예시 값
+    private int attemptedRefreshesToday = 0;
+
+    @Autowired
+    public ApiRateLimitedCacheRefreshScheduler(BusArrivalCacheService cacheService,
+                                               ArrivalBusInfoHandler arrivalBusInfoHandler) {
+        this.cacheService = cacheService;
+        this.arrivalBusInfoHandler = arrivalBusInfoHandler;
+    }
+
+    // 자정마다 오늘 갱신 시도한 정류소 개수 초기화
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정
+    public void resetDailyRefreshAttemptCount() {
+        logger.info("Resetting daily station cache refresh attempt count.");
+        attemptedRefreshesToday = 0;
+    }
+
+    // 예: 15분마다 실행. 구독 중인 역 중 일부를 순차적으로 캐시 갱신 시도
+    @Scheduled(fixedRate = 900000, initialDelay = 120000) // 2분 후 시작, 이후 15분 간격
+    public void refreshSubscribedStationCaches() {
+        Set<String> subscribedStationIds = arrivalBusInfoHandler.getSubscribedStationIds();
+        if (subscribedStationIds.isEmpty()) {
+            logger.debug("No active subscriptions. Skipping cache refresh attempt cycle.");
+            return;
+        }
+
+        if (attemptedRefreshesToday >= MAX_STATIONS_TO_ATTEMPT_REFRESH_PER_DAY) {
+            logger.info("Max stations to attempt refresh per day ({}) reached. Skipping further cache refresh attempts for today.", MAX_STATIONS_TO_ATTEMPT_REFRESH_PER_DAY);
+            return;
+        }
+
+        List<String> stationsToProcess = new ArrayList<>(subscribedStationIds);
+        Collections.shuffle(stationsToProcess); // 매번 같은 순서로 처리되는 것을 방지
+
+        int refreshedThisCycle = 0;
+        for (String stationId : stationsToProcess) {
+            if (attemptedRefreshesToday >= MAX_STATIONS_TO_ATTEMPT_REFRESH_PER_DAY) {
+                logger.info("Daily limit for attempting cache refreshes reached during this cycle.");
+                break;
+            }
+
+            logger.info("Attempting to refresh cache from API (via CacheService) for stationId: {}", stationId);
+            try {
+                // forceApiRefresh = true로 호출하여 캐시 갱신 시도.
+                // 실제 API 호출 여부는 BusArrivalCacheService -> SeoulBusArrivalServiceImpl -> ApiCallManager가 결정.
+                cacheService.getArrivalsForStation(stationId, true);
+                attemptedRefreshesToday++;
+                refreshedThisCycle++;
+                logger.info("Cache refresh attempt initiated for stationId: {}. Total attempts today: {}", stationId, attemptedRefreshesToday);
+            } catch (Exception e) {
+                // cacheService.getArrivalsForStation 내부에서 예외가 발생할 수 있으나,
+                // 해당 메소드는 API 호출 실패 시에도 가능한 이전 캐시를 반환하거나 빈 리스트를 반환하도록 설계됨.
+                // 스케줄러 레벨에서는 이로 인해 스케줄러 자체가 중단되지 않도록 로깅만 처리.
+                logger.error("Error during scheduled cache refresh attempt for stationId {}: {}", stationId, e.getMessage());
+            }
+
+            // 한 번의 스케줄링 주기에서 너무 많은 시도를 방지 (선택적)
+            // if (refreshedThisCycle >= 5) { // 예: 한 주기에 최대 5개 역만 시도
+            //    logger.info("Attempted to refresh {} stations this cycle. Pausing until next cycle.", refreshedThisCycle);
+            //    break;
+            // }
+        }
+        logger.info("Finished cache refresh attempt cycle. Attempted {} stations this cycle. Total attempts today: {}", refreshedThisCycle, attemptedRefreshesToday);
+    }
+}

--- a/src/main/java/com/jhinslog/buswhich/scheduler/BusArrivalUpdateScheduler.java
+++ b/src/main/java/com/jhinslog/buswhich/scheduler/BusArrivalUpdateScheduler.java
@@ -1,0 +1,101 @@
+package com.jhinslog.buswhich.scheduler;
+
+import com.jhinslog.buswhich.service.BusArrivalCacheService; // 캐시 서비스 사용
+import com.jhinslog.buswhich.dto.response.SpecificStationArrivalDto;
+import com.jhinslog.buswhich.websocket.ArrivalBusInfoHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class BusArrivalUpdateScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(BusArrivalUpdateScheduler.class);
+
+    private final BusArrivalCacheService cacheService;
+    private final ArrivalBusInfoHandler arrivalBusInfoHandler;
+
+    // 각 정류소별 마지막으로 클라이언트에게 정보를 브로드캐스팅한 시간
+    private final Map<String, LocalDateTime> lastBroadcastTimeMap = new ConcurrentHashMap<>();
+
+    @Autowired
+    public BusArrivalUpdateScheduler(BusArrivalCacheService cacheService,
+                                     ArrivalBusInfoHandler arrivalBusInfoHandler) {
+        this.cacheService = cacheService;
+        this.arrivalBusInfoHandler = arrivalBusInfoHandler;
+    }
+
+    // 이 스케줄러는 API를 직접 호출하지 않으므로 비교적 자주 실행 가능 (예: 10초)
+    // 클라이언트에게 "실시간처럼 보이는" 업데이트를 제공하는 역할
+    @Scheduled(fixedRate = 10000, initialDelay = 5000) // 5초 후 시작, 이후 10초 간격
+    public void broadcastUpdatesFromCache() {
+        Set<String> subscribedStationIds = arrivalBusInfoHandler.getSubscribedStationIds();
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        if (subscribedStationIds.isEmpty()) {
+            return; // 구독자가 없으면 작업 없음
+        }
+
+        for (String stationId : subscribedStationIds) {
+            try {
+                // API를 직접 호출하지 않고 캐시에서 데이터를 가져옴 (forceApiRefresh = false)
+                // cacheService.getArrivalsForStation는 내부적으로 만료된 캐시라도 반환할 수 있음
+                List<SpecificStationArrivalDto> cachedArrivalInfo = cacheService.getArrivalsForStation(stationId, false);
+
+                if (cachedArrivalInfo == null) { // 혹시 모를 null 반환에 대비
+                    cachedArrivalInfo = Collections.emptyList();
+                }
+
+                // 동적 업데이트 주기 로직 (남은 시간 기준)
+                long broadcastIntervalSeconds = calculateBroadcastInterval(cachedArrivalInfo);
+                LocalDateTime lastBroadcast = lastBroadcastTimeMap.get(stationId);
+
+                if (lastBroadcast == null || lastBroadcast.plusSeconds(broadcastIntervalSeconds).isBefore(currentTime)) {
+                    // cachedArrivalInfo가 비어있더라도 (예: 정보 없음, API 제한으로 데이터 못 가져옴)
+                    // 클라이언트에게는 현재 상태(빈 정보)를 알려주는 것이 좋을 수 있음.
+                    arrivalBusInfoHandler.broadcastArrivalUpdates(stationId, cachedArrivalInfo);
+                    lastBroadcastTimeMap.put(stationId, currentTime);
+                    if (!cachedArrivalInfo.isEmpty()) {
+                        logger.debug("Broadcasted cached updates for stationId: {} (Interval: {}s, {} items)", stationId, broadcastIntervalSeconds, cachedArrivalInfo.size());
+                    } else {
+                        logger.debug("Broadcasted empty info for stationId: {} (Interval: {}s) - No data in cache or from service.", stationId, broadcastIntervalSeconds);
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Error during cache-based broadcast for stationId {}: {}", stationId, e.getMessage(), e);
+            }
+        }
+    }
+
+    private long calculateBroadcastInterval(List<SpecificStationArrivalDto> arrivalInfo) {
+        if (arrivalInfo.isEmpty()) {
+            return 60L; // 정보 없으면 1분 간격으로 체크 (클라이언트에게 no_info 계속 보내는 것 방지 위함)
+        }
+        // 첫 번째 버스 기준으로 판단 (더 정교하게 하려면 모든 버스 고려)
+        SpecificStationArrivalDto firstBus = arrivalInfo.get(0);
+        if (firstBus.getFirstRemainingSec() == null) {
+            return 60L; // 남은 시간 정보 없으면 1분
+        }
+
+        int remainingSec = firstBus.getFirstRemainingSec();
+
+        if (remainingSec < 0) return 10L; // 이미 도착했거나 지나간 경우 빠르게 다음 정보 확인
+
+        if (remainingSec < 180) { // 3분 미만
+            return 10L; // 10초 간격
+        } else if (remainingSec < 300) { // 5분 미만 (3분 이상)
+            return 30L; // 30초 간격
+        } else { // 5분 이상
+            return 60L; // 1분 간격
+        }
+    }
+}

--- a/src/main/java/com/jhinslog/buswhich/service/ApiCallManager.java
+++ b/src/main/java/com/jhinslog/buswhich/service/ApiCallManager.java
@@ -1,0 +1,92 @@
+package com.jhinslog.buswhich.service;
+
+import com.jhinslog.buswhich.util.ApiOperation; // 수정된 import 경로
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class ApiCallManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiCallManager.class);
+    private final Map<ApiOperation, AtomicInteger> dailyCallCounts = new ConcurrentHashMap<>();
+    private static final int DAILY_LIMIT_PER_FUNCTION = 1000; // 기능별 일일 호출 제한
+
+    @PostConstruct
+    public void init() {
+        for (ApiOperation functionName : ApiOperation.values()) {
+            dailyCallCounts.put(functionName, new AtomicInteger(0));
+        }
+        logger.info("ApiCallManager initialized with {} API functions.", ApiOperation.values().length);
+    }
+
+    /**
+     * 특정 API 기능에 대한 호출이 가능한지 확인합니다.
+     * @param functionName 확인할 API 기능
+     * @return 호출 가능하면 true, 아니면 false
+     */
+    public boolean canMakeCall(ApiOperation functionName) {
+        AtomicInteger count = dailyCallCounts.get(functionName);
+        if (count == null) {
+            logger.warn("No call count found for API function: {}. Assuming limit not reached.", functionName);
+            return true;
+        }
+        boolean canCall = count.get() < DAILY_LIMIT_PER_FUNCTION;
+        if (!canCall) {
+            logger.warn("Daily API call limit ({}) reached for function: {}", DAILY_LIMIT_PER_FUNCTION, functionName);
+        }
+        return canCall;
+    }
+
+    /**
+     * 특정 API 기능의 호출 횟수를 1 증가시킵니다.
+     * @param functionName 호출된 API 기능
+     */
+    public void recordCall(ApiOperation functionName) {
+        recordCalls(functionName, 1);
+    }
+
+    /**
+     * 특정 API 기능의 호출 횟수를 지정된 만큼 증가시킵니다.
+     * @param functionName 호출된 API 기능
+     * @param count 증가시킬 횟수
+     */
+    public void recordCalls(ApiOperation functionName, int count) {
+        if (count <= 0) return;
+
+        AtomicInteger currentCount = dailyCallCounts.get(functionName);
+        if (currentCount != null) {
+            int newCount = currentCount.addAndGet(count);
+            logger.debug("API call recorded for {}. Count: {}, Total today: {}", functionName, count, newCount);
+            if (newCount >= DAILY_LIMIT_PER_FUNCTION) {
+                logger.warn("Daily API call limit ({}) just reached or exceeded for function: {}. Current count: {}",
+                        DAILY_LIMIT_PER_FUNCTION, functionName, newCount);
+            }
+        } else {
+            logger.warn("Attempted to record call for uninitialized API function: {}", functionName);
+        }
+    }
+
+    /**
+     * 매일 자정 모든 API 기능의 호출 횟수를 초기화합니다.
+     */
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 00:00:00에 실행
+    public void resetDailyCounts() {
+        logger.info("Resetting all daily API call counts.");
+        for (ApiOperation functionName : ApiOperation.values()) {
+            dailyCallCounts.get(functionName).set(0);
+        }
+        logger.info("All daily API call counts have been reset.");
+    }
+
+    public int getCurrentCallCount(ApiOperation functionName) {
+        AtomicInteger count = dailyCallCounts.get(functionName);
+        return (count != null) ? count.get() : 0;
+    }
+}

--- a/src/main/java/com/jhinslog/buswhich/service/BusArrivalCacheService.java
+++ b/src/main/java/com/jhinslog/buswhich/service/BusArrivalCacheService.java
@@ -1,0 +1,124 @@
+package com.jhinslog.buswhich.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jhinslog.buswhich.domain.cache.CachedStationArrival;
+import com.jhinslog.buswhich.dto.response.SpecificStationArrivalDto;
+import com.jhinslog.buswhich.repository.cache.CachedStationArrivalRepository;
+import com.jhinslog.buswhich.util.ApiOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class BusArrivalCacheService {
+
+    private static final Logger logger = LoggerFactory.getLogger(BusArrivalCacheService.class);
+    private static final ApiOperation TARGET_API_OPERATION = ApiOperation.GET_ARR_INFO_BY_ST_ID_LIST; //정류소 ID 기반 일반 버스 도착정보
+
+    private final CachedStationArrivalRepository cacheRepository;
+    private final BusArrivalService actualBusArrivalService;
+    private final ObjectMapper objectMapper;
+    private final ApiCallManager apiCallManager;
+
+
+    public static final long CACHE_INTERNAL_TTL_MINUTES = 5; //테스트 코드에서 접근하기 위해 public으로 수정
+
+    @Autowired
+    public BusArrivalCacheService(CachedStationArrivalRepository cacheRepository,
+                                  @Qualifier("seoulBusArrivalServiceImpl") BusArrivalService actualBusArrivalService,
+                                  ObjectMapper objectMapper,
+                                  ApiCallManager apiCallManager) {
+        this.cacheRepository = cacheRepository;
+        this.actualBusArrivalService = actualBusArrivalService;
+        this.objectMapper = objectMapper;
+        this.apiCallManager = apiCallManager;
+    }
+
+    @Transactional
+    public List<SpecificStationArrivalDto> getArrivalsForStation(String stationId, boolean forceApiRefresh) {
+        Optional<CachedStationArrival> cachedOpt = cacheRepository.findByStationId(stationId);
+        LocalDateTime now = LocalDateTime.now();
+
+        // 1. 강제 새로고침이 아닌 유효한 캐시가 존재할 경우 캐시 반환.
+        if (!forceApiRefresh && cachedOpt.isPresent() && cachedOpt.get().getCacheExpiryTime().isAfter(now)) {
+            logger.debug("Cache hit for stationId: {}. Returning cached data valid until {}.",
+                    stationId, cachedOpt.get().getCacheExpiryTime());
+            return deserializeArrivalData(cachedOpt.get().getArrivalDataJson());
+        }
+
+        // 2. 캐시 미스, 만료, 강제 새로고침 시 API 호출 시도
+        // (첫 번째 if 문을 통과했다면, 이 지점은 API 호출을 고려해야 하는 상황임)
+        logger.info("Cache miss, expired, or force refresh for stationId: {}. Attempting API call.", stationId);
+
+        // API 호출 제한 확인
+        if (!apiCallManager.canMakeCall(TARGET_API_OPERATION)) {
+            logger.warn("API call limit reached for {}. Cannot refresh cache for stationId: {}.",
+                    TARGET_API_OPERATION, stationId);
+            // 호출 제한 시, 만료된 캐시라도 있으면 반환, 없으면 빈 리스트 반환
+            return cachedOpt.map(c -> deserializeArrivalData(c.getArrivalDataJson())).orElse(Collections.emptyList());
+        }
+
+        try {
+            List<SpecificStationArrivalDto> freshData = actualBusArrivalService.getArrivalsByStationId(stationId);
+
+            apiCallManager.recordCall(TARGET_API_OPERATION);    //API 호출 성공 시, ApiCallManager를 통해 호출 횟수 카운트 증가
+
+            if (freshData != null) {
+                String jsonData = serializeArrivalData(freshData);
+                LocalDateTime apiCallTime = LocalDateTime.now();
+                CachedStationArrival newCache = new CachedStationArrival(
+                        stationId,
+                        jsonData,
+                        apiCallTime,
+                        apiCallTime.plusMinutes(CACHE_INTERNAL_TTL_MINUTES)
+                );
+                cacheRepository.save(newCache);
+                logger.info("API data fetched and cached for stationId: {}. Cache expires at: {}",
+                        stationId, newCache.getCacheExpiryTime());
+                return freshData;
+            } else {
+                logger.info("API returned no data for stationId: {}. Returning empty list.", stationId);
+                return Collections.emptyList();
+            }
+        } catch (Exception e) {
+            logger.error("Error fetching fresh data from API for stationId: {}. Returning stale cache if available.",
+                    stationId, e);
+            return cachedOpt.map(c -> deserializeArrivalData(c.getArrivalDataJson())).orElse(Collections.emptyList());
+        }
+        // 이 지점은 도달하지 않으므로 추가적인 return이나 로직이 필요 없습니다.
+    }
+
+    private String serializeArrivalData(List<SpecificStationArrivalDto> data) {
+        if (data == null) { // null인 경우 빈 배열 문자열로 처리
+            return "[]";
+        }
+        try {
+            return objectMapper.writeValueAsString(data);
+        } catch (JsonProcessingException e) {
+            logger.error("Error serializing arrival data for caching", e);
+            return "[]";
+        }
+    }
+
+    private List<SpecificStationArrivalDto> deserializeArrivalData(String jsonData) {
+        if (jsonData == null || jsonData.isEmpty() || "[]".equals(jsonData)) {
+            return Collections.emptyList();
+        }
+        try {
+            return objectMapper.readValue(jsonData, new TypeReference<List<SpecificStationArrivalDto>>() {});
+        } catch (JsonProcessingException e) {
+            logger.error("Error deserializing cached arrival data", e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/jhinslog/buswhich/service/impl/SeoulBusArrivalServiceImpl.java
+++ b/src/main/java/com/jhinslog/buswhich/service/impl/SeoulBusArrivalServiceImpl.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jhinslog.buswhich.dto.response.RouteAllArrivalsResponseDto;
 import com.jhinslog.buswhich.dto.response.SpecificStationArrivalDto;
 import com.jhinslog.buswhich.dto.seoulbus.api.*;
+import com.jhinslog.buswhich.service.ApiCallManager;
 import com.jhinslog.buswhich.service.BusArrivalService;
+import com.jhinslog.buswhich.util.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -25,43 +27,47 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
-@Service
+@Service("seoulBusArrivalServiceImpl")
 public class SeoulBusArrivalServiceImpl implements BusArrivalService {
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
+    private final ApiCallManager apiCallManager; // ApiCallManager 주입
 
     @Value("${public-api.seoul-bus.service-key}")
     private String serviceKey;
 
-    // application-dev.yml에 정의된 operation URL
     @Value("${public-api.seoul-bus.operations.getArrInfoByRouteAllList}")
-    private String arrInfoByRouteAllListUrl;    // 경유노선 전체 정류소 도착예정정보를 조회한다
+    private String arrInfoByRouteAllListUrl;
 
     @Value("${public-api.seoul-bus.operations.getRouteByStationList}")
-    private String routeByStationListUrl; // 정류소고유번호를 입력받아 경유하는 노선목록을 조회한다.
+    private String routeByStationListUrl;
 
-    public SeoulBusArrivalServiceImpl(RestTemplate restTemplate, ObjectMapper objectMapper) {
+    public SeoulBusArrivalServiceImpl(RestTemplate restTemplate, ObjectMapper objectMapper, ApiCallManager apiCallManager) {
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
+        this.apiCallManager = apiCallManager;
     }
 
     @Override
     public RouteAllArrivalsResponseDto getArrivalsByRoute(String busRouteId) {
+        if (!apiCallManager.canMakeCall(ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST)) {
+            log.warn("API call limit reached for {}. Aborting call for busRouteId: {}", ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST, busRouteId);
+            return buildErrorResponse(busRouteId, "일일 API 호출 한도 초과 [" + ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST.getOperationName() + "]");
+        }
 
-        // 1. API URL 구성
         URI apiUri = UriComponentsBuilder.fromHttpUrl(arrInfoByRouteAllListUrl)
                 .queryParam("serviceKey", serviceKey)
                 .queryParam("busRouteId", busRouteId)
-                .queryParam("resultType", "json") // JSON 형태로 데이터 요청
-                .build(true) // serviceKey가 이미 인코딩된 값일 경우 true
+                .queryParam("resultType", "json")
+                .build(true)
                 .toUri();
 
         log.info("Requesting API URL (JSON): {}", apiUri.toString());
 
         try {
-            // 2. API 호출 및 JSON 응답을 문자열로 받기
             ResponseEntity<String> responseEntity = restTemplate.getForEntity(apiUri, String.class);
+            apiCallManager.recordCall(ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST);
             String jsonResponse = responseEntity.getBody();
 
             if (jsonResponse == null || jsonResponse.trim().isEmpty()) {
@@ -71,44 +77,37 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
 
             log.debug("JSON Response for busRouteId {}: {}", busRouteId, jsonResponse);
 
-            // 3. JSON 문자열을 DTO로 변환 (SeoulBusResponseDto<SeoulBusArrivalItemDto> 사용)
             TypeReference<SeoulBusResponseDto<SeoulBusArrivalItemDto>> typeRef =
                     new TypeReference<SeoulBusResponseDto<SeoulBusArrivalItemDto>>() {};
             SeoulBusResponseDto<SeoulBusArrivalItemDto> apiResponse = objectMapper.readValue(jsonResponse, typeRef);
 
-            // 4. API 응답 헤더 유효성 검사
             if (apiResponse == null || apiResponse.getMsgHeader() == null) {
                 log.error("Failed to parse API response or msgHeader is null for busRouteId: {}", busRouteId);
                 return buildErrorResponse(busRouteId, "API 응답 파싱 실패");
             }
 
             SeoulBusMsgHeaderDto msgHeader = apiResponse.getMsgHeader();
-            if (!"0".equals(msgHeader.getHeaderCd())) { // "0"이 성공 코드
+            if (!"0".equals(msgHeader.getHeaderCd())) {
                 log.error("API error for busRouteId: {}. HeaderCd: {}, HeaderMsg: {}",
                         busRouteId, msgHeader.getHeaderCd(), msgHeader.getHeaderMsg());
                 return buildErrorResponse(busRouteId, "API 오류: " + msgHeader.getHeaderMsg());
             }
 
-            // 5. itemList 추출
             SeoulBusMsgBodyDto<SeoulBusArrivalItemDto> msgBody = apiResponse.getMsgBody();
             if (msgBody == null || msgBody.getItemList() == null || msgBody.getItemList().isEmpty()) {
                 log.info("No arrival information found for busRouteId: {} (itemList is null or empty)", busRouteId);
-                // 아이템이 없는 경우, 노선 정보 없이 빈 도착 정보 리스트 반환
                 return RouteAllArrivalsResponseDto.builder()
                         .routeId(busRouteId)
-                        .routeName("정보 없음") // 또는 API에서 노선명을 별도로 가져오는 로직 추가 필요
-                        .routeType("정보 없음")
+                        .routeName(null)
+                        .routeType(null)
                         .stationArrivals(Collections.emptyList())
                         .build();
             }
 
             List<SeoulBusArrivalItemDto> arrivalItems = msgBody.getItemList();
-
-            // 6. RouteAllArrivalsResponseDto로 변환
-            // 첫 번째 아이템에서 노선명과 노선 유형 추출 (모든 아이템이 동일 노선이라고 가정)
-            String routeName = arrivalItems.get(0).getBusRouteAbrv(); // 안내용 노선 약칭 사용
+            String routeName = arrivalItems.get(0).getBusRouteAbrv();
             if (routeName == null || routeName.trim().isEmpty()) {
-                routeName = arrivalItems.get(0).getRtNm(); // DB 관리용 노선명 사용
+                routeName = arrivalItems.get(0).getRtNm();
             }
             String routeTypeApi = arrivalItems.get(0).getRouteType();
 
@@ -117,15 +116,21 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
                     .collect(Collectors.toList());
 
             return RouteAllArrivalsResponseDto.builder()
-                    .routeId(busRouteId) // 입력받은 busRouteId 사용
+                    .routeId(busRouteId)
                     .routeName(routeName)
-                    .routeType(formatRouteType(routeTypeApi)) // 코드값을 문자열로 변환
+                    .routeType(formatRouteType(routeTypeApi))
                     .stationArrivals(stationArrivals)
                     .build();
 
-        } catch (IOException e) { // ObjectMapper.readValue()는 IOException을 던질 수 있음
+        } catch (IOException e) {
             log.error("Error parsing JSON response for busRouteId: {}", busRouteId, e);
             return buildErrorResponse(busRouteId, "JSON 파싱 오류: " + e.getMessage());
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            log.error("HTTP Error {} for getArrInfoByRouteAllList for busRouteId {}. Response: {}", e.getStatusCode(), busRouteId, e.getResponseBodyAsString(), e);
+            return buildErrorResponse(busRouteId, "API 통신 오류 (HTTP " + e.getStatusCode() + ")");
+        } catch (RestClientException e) {
+            log.error("Error calling API getArrInfoByRouteAllList for busRouteId {}: {}", busRouteId, e.getMessage());
+            return buildErrorResponse(busRouteId, "API 호출 중 오류 발생: " + e.getMessage());
         } catch (Exception e) {
             log.error("Error processing bus arrival info for busRouteId: {}", busRouteId, e);
             return buildErrorResponse(busRouteId, "처리 중 오류 발생: " + e.getMessage());
@@ -134,18 +139,22 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
 
     @Override
     public List<SpecificStationArrivalDto> getArrivalsByStationId(String arsId) {
-        // 1단계: arsId를 사용하여 해당 정류소를 경유하는 모든 노선 ID 목록 가져오기
         List<String> busRouteIds = getBusRouteIdsForStation(arsId);
 
         if (busRouteIds.isEmpty()) {
-            log.info("No bus routes found passing through station with arsId: {}", arsId);
+            log.info("No bus routes found passing through station with arsId: {} or API limit reached for getRouteByStationList.", arsId);
             return Collections.emptyList();
         }
 
         List<SpecificStationArrivalDto> allArrivalsAtStation = new ArrayList<>();
 
-        // 2단계: 각 노선 ID에 대해 전체 정류소 목록 및 상세 도착 정보 조회 후 필터링
         for (String busRouteId : busRouteIds) {
+            if (!apiCallManager.canMakeCall(ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST)) {
+                log.warn("API call limit reached for {}. Skipping route {} for station {}",
+                        ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST, busRouteId, arsId);
+                continue;
+            }
+
             try {
                 URI routeDetailApiUri = UriComponentsBuilder.fromHttpUrl(arrInfoByRouteAllListUrl)
                         .queryParam("serviceKey", serviceKey)
@@ -156,6 +165,7 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
 
                 log.debug("Requesting all stops for route {} to find info for arsId {}: {}", busRouteId, arsId, routeDetailApiUri);
                 ResponseEntity<String> responseEntity = restTemplate.getForEntity(routeDetailApiUri, String.class);
+                apiCallManager.recordCall(ApiOperation.GET_ARR_INFO_BY_ROUTE_ALL_LIST);
                 String jsonResponse = responseEntity.getBody();
 
                 if (jsonResponse == null || jsonResponse.trim().isEmpty()) {
@@ -175,8 +185,8 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
                 SeoulBusMsgBodyDto<SeoulBusArrivalItemDto> msgBody = apiResponse.getMsgBody();
                 if (msgBody != null && msgBody.getItemList() != null) {
                     msgBody.getItemList().stream()
-                            .filter(item -> arsId.equals(item.getArsId())) // arsId로 필터링
-                            .findFirst() // 해당 정류소 정보를 찾으면
+                            .filter(item -> arsId.equals(item.getArsId()))
+                            .findFirst()
                             .ifPresent(item -> allArrivalsAtStation.add(transformToStationSpecificArrivalDto(item)));
                 }
             } catch (IOException e) {
@@ -192,11 +202,15 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
         return allArrivalsAtStation;
     }
 
-    // 1단계를 위한 헬퍼 메소드: arsId로 해당 정류소를 경유하는 노선 ID 목록 조회
     private List<String> getBusRouteIdsForStation(String arsId) {
+        if (!apiCallManager.canMakeCall(ApiOperation.GET_ROUTE_BY_STATION_LIST)) {
+            log.warn("API call limit reached for {}. Aborting call for arsId: {}", ApiOperation.GET_ROUTE_BY_STATION_LIST, arsId);
+            return Collections.emptyList();
+        }
+
         URI apiUri = UriComponentsBuilder.fromHttpUrl(routeByStationListUrl)
                 .queryParam("serviceKey", serviceKey)
-                .queryParam("arsId", arsId) // API 요청 변수명에 맞게
+                .queryParam("arsId", arsId)
                 .queryParam("resultType", "json")
                 .build(true)
                 .toUri();
@@ -204,6 +218,7 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
         log.debug("Requesting routes for station (arsId: {}): {}", arsId, apiUri);
         try {
             ResponseEntity<String> responseEntity = restTemplate.getForEntity(apiUri, String.class);
+            apiCallManager.recordCall(ApiOperation.GET_ROUTE_BY_STATION_LIST);
             String jsonResponse = responseEntity.getBody();
 
             if (jsonResponse == null || jsonResponse.trim().isEmpty()) {
@@ -224,7 +239,7 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
             if (msgBody != null && msgBody.getItemList() != null) {
                 return msgBody.getItemList().stream()
                         .map(SeoulBusRouteByStationItemDto::getBusRouteId)
-                        .filter(Objects::nonNull) // busRouteId가 null이 아닌 경우만
+                        .filter(Objects::nonNull)
                         .distinct()
                         .collect(Collectors.toList());
             }
@@ -249,7 +264,6 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
                 .build();
     }
 
-    // SeoulBusArrivalItemDto -> StationSpecificArrivalDto 변환 헬퍼 메소드
     private SpecificStationArrivalDto transformToStationSpecificArrivalDto(SeoulBusArrivalItemDto item) {
         return SpecificStationArrivalDto.builder()
                 .stationId(item.getStId())
@@ -257,15 +271,13 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
                 .arsId(item.getArsId())
                 .stationOrder(item.getStaOrd())
                 .direction(item.getDir())
-                // 첫 번째 버스 정보
                 .firstArrivalMsg(item.getArrmsg1())
-                .firstRemainingSec(parseIntegerSafe(item.getExps1())) // exps1: 지수평활 도착예정시간(초)
+                .firstRemainingSec(parseIntegerSafe(item.getExps1()))
                 .firstBusType(formatBusType(item.getBusType1()))
                 .firstPlainNo(item.getPlainNo1())
                 .firstIsLowFloor(isLowFloor(item.getBusType1()))
                 .firstCongestion(formatCongestion(item.getBrerdeDiv1(), item.getBrdrdeNum1(), item.getRouteType()))
                 .firstIsLastBus(isLastBus(item.getIsLast1()))
-                // 두 번째 버스 정보
                 .secondArrivalMsg(item.getArrmsg2())
                 .secondRemainingSec(parseIntegerSafe(item.getExps2()))
                 .secondBusType(formatBusType(item.getBusType2()))
@@ -273,20 +285,15 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
                 .secondIsLowFloor(isLowFloor(item.getBusType2()))
                 .secondCongestion(formatCongestion(item.getBrerdeDiv2(), item.getBrdrdeNum2(), item.getRouteType()))
                 .secondIsLastBus(isLastBus(item.getIsLast2()))
-                // 우회 여부
-                .detourYn("11".equals(item.getDeTourAt())) // "00": 정상, "11": 우회
+                .detourYn("11".equals(item.getDeTourAt()))
                 .build();
     }
 
-    // --- 데이터 가공을 위한 헬퍼 메소드들 ---
     private Integer parseIntegerSafe(String value) {
         if (value == null || value.trim().isEmpty() || "0".equals(value)) {
-            // "0"은 실제 0초일 수도 있고, 데이터 없음을 의미할 수도 있음. API 명세에 따라 해석.
-            // 여기서는 도착 예정 시간이므로 0은 곧 도착 또는 정보 없음으로 간주될 수 있음. null로 반환하여 구분.
             return null;
         }
         try {
-            // 숫자만 있는지 간단히 확인 (더 엄밀한 검증은 정규식 사용 가능)
             if (!value.matches("\\d+")) {
                 log.warn("Non-numeric value encountered for time: '{}'", value);
                 return null;
@@ -298,7 +305,6 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
         }
     }
 
-    // 버스 타입 정보
     private String formatBusType(String busTypeCode) {
         if (busTypeCode == null) return "정보없음";
         return switch (busTypeCode) {
@@ -310,41 +316,34 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
     }
 
     private Boolean isLowFloor(String busTypeCode) {
-        return "1".equals(busTypeCode); // 1: 저상버스
+        return "1".equals(busTypeCode);
     }
 
-    // 혼잡도 변환 (brerdeDiv, brdrdeNum 사용)
     private String formatCongestion(String divCode, String numCode, String routeType) {
         if (divCode == null || numCode == null) return "정보없음";
-
-        // brerde_Div1/2: brdrde_Num1/2 값의 의미 구분(0: 데이터 없음, 2: 재차인원, 4:혼잡도)
-        // brdrde_Num1/2: 재차구분 4일 때 혼잡도(0: 데이터없음, 3: 여유, 4: 보통, 5: 혼잡)
-        //                재차구분 2일 때 재차인원 또는 잔여좌석수(routeType = 6) 서울시 광역버스
         switch (divCode) {
-            case "4": // 혼잡도
+            case "4":
                 return switch (numCode) {
                     case "3" -> "여유";
                     case "4" -> "보통";
                     case "5" -> "혼잡";
-                    default -> "정보없음"; // "0" 또는 기타 값
+                    default -> "정보없음";
                 };
-            case "2": // 재차인원 또는 잔여좌석
-                if ("6".equals(routeType)) { // 광역버스
+            case "2":
+                if ("6".equals(routeType)) {
                     return "잔여좌석: " + numCode;
                 } else {
                     return "재차인원: " + numCode;
                 }
-            default: // "0" 또는 기타 값
+            default:
                 return "정보없음";
         }
     }
 
-    //막차 여부
     private Boolean isLastBus(String isLastCode) {
-        return "1".equals(isLastCode); // 0:막차아님, 1:막차
+        return "1".equals(isLastCode);
     }
 
-    //노선 유형
     private String formatRouteType(String routeTypeCode) {
         if (routeTypeCode == null) return "정보없음";
         return switch (routeTypeCode) {
@@ -361,5 +360,4 @@ public class SeoulBusArrivalServiceImpl implements BusArrivalService {
             default -> "기타(" + routeTypeCode + ")";
         };
     }
-
 }

--- a/src/main/java/com/jhinslog/buswhich/util/ApiOperation.java
+++ b/src/main/java/com/jhinslog/buswhich/util/ApiOperation.java
@@ -1,0 +1,29 @@
+package com.jhinslog.buswhich.util;
+
+public enum ApiOperation {
+    // 서울특별시_버스도착정보조회_서비스
+    GET_ARR_INFO_BY_ROUTE_ALL_LIST("getArrInfoByRouteAllList"), // 경유노선 전체 정류소 도착예정정보
+    GET_ARR_INFO_BY_ROUTE_LIST("getArrInfoByRouteList"),        // 특정노선 특정정류소 도착예정정보
+    GET_LOW_ARR_INFO_BY_ROUTE_LIST("getLowArrInfoByRouteList"), // 저상버스 특정노선 특정정류소 도착예정정보
+    GET_ARR_INFO_BY_ST_ID_LIST("getArrInfoByStIdList"),         // 일반버스 특정정류소 도착예정정
+    GET_LOW_ARR_INFO_BY_ST_ID_LIST("getLowArrInfoByStIdList"),  // 저상버스 특정정류소 도착예정정보
+
+    // 서울특별시_정류소정보조회 서비스
+    GET_STATION_BY_NAME_LIST("getStationByNameList"),           // 정류소명 검색
+    GET_STATION_BY_UID_ITEM("getStationByUidItem"),             // 정류소 ARS번호로 정류소정보조회
+    GET_ROUTE_BY_STATION_LIST("getRouteByStationList"),         // 정류소고유번호로 경유노선목록조회
+    GET_BUS_TIME_BY_STATION_LIST("getBustimeByStationList"),    // 정류소고유번호로 버스 첫막차시간 조회
+    GET_LOW_STATION_BY_NAME_LIST("getLowStationByNameList"),    // 저상버스 정류소명 검색
+    GET_LOW_STATION_BY_UID_LIST("getLowStaionByUidList"),       // 저상버스 정류소 ARS번호로 정류소정보조회
+    GET_STATIONS_BY_POS_LIST("getStaionsByPosList");            // 좌표기반 근접정류소 조회
+
+    private final String operationName;
+
+    ApiOperation(String operationName) {
+        this.operationName = operationName;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+}

--- a/src/main/java/com/jhinslog/buswhich/websocket/ArrivalBusInfoHandler.java
+++ b/src/main/java/com/jhinslog/buswhich/websocket/ArrivalBusInfoHandler.java
@@ -2,9 +2,9 @@ package com.jhinslog.buswhich.websocket;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jhinslog.buswhich.dto.request.WebSocketSubscriptionRequestDto;
+import com.jhinslog.buswhich.dto.request.WebSocketSubscriptionRequestDto; // 이 DTO를 사용합니다.
 import com.jhinslog.buswhich.dto.response.SpecificStationArrivalDto;
-import com.jhinslog.buswhich.service.BusArrivalService;
+import com.jhinslog.buswhich.service.BusArrivalCacheService; // BusArrivalCacheService 사용
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,29 +15,36 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap; // HashMap import 추가
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 @Component
 public class ArrivalBusInfoHandler extends TextWebSocketHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ArrivalBusInfoHandler.class);
     private final ObjectMapper objectMapper;
-    private final BusArrivalService busArrivalService;
+    private final BusArrivalCacheService cacheService; // BusArrivalService 대신 BusArrivalCacheService 주입
 
-    // 세션과 해당 세션이 구독한 정류소 ID를 매핑하여 관리
-    private final Map<WebSocketSession, String> sessionStationMap = new ConcurrentHashMap<>();
+    // stationId를 키로 하고, 해당 정류장을 구독하는 WebSocketSession 세트를 값으로 가짐
+    private final Map<String, Set<WebSocketSession>> stationSubscriptions = new ConcurrentHashMap<>();
+    // WebSocketSession을 키로 하고, 해당 세션이 구독하는 stationId 세트를 값으로 가짐 (연결 종료 시 구독 해제용)
+    private final Map<WebSocketSession, Set<String>> sessionSubscriptions = new ConcurrentHashMap<>();
 
     @Autowired
-    public ArrivalBusInfoHandler(ObjectMapper objectMapper, BusArrivalService busArrivalService) {
+    public ArrivalBusInfoHandler(ObjectMapper objectMapper, BusArrivalCacheService cacheService) { // 생성자 수정
         this.objectMapper = objectMapper;
-        this.busArrivalService = busArrivalService;
+        this.cacheService = cacheService; // cacheService 주입
     }
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         logger.info("WebSocket connection established: {} (ID: {})", session.getRemoteAddress(), session.getId());
+        sessionSubscriptions.put(session, new CopyOnWriteArraySet<>()); // 세션별 구독 목록 초기화
         // 클라이언트에게 연결 성공 및 구독 안내 메시지 전송
         sendMessage(session, Map.of(
                 "type", "connection_success",
@@ -53,21 +60,29 @@ public class ArrivalBusInfoHandler extends TextWebSocketHandler {
 
         try {
             WebSocketSubscriptionRequestDto requestDto = objectMapper.readValue(payload, WebSocketSubscriptionRequestDto.class);
+            String stationId = requestDto.getStationId(); // WebSocketSubscriptionRequestDto 사용
+            String actionType = requestDto.getType();     // WebSocketSubscriptionRequestDto 사용
 
-            if (requestDto.getType() == null) {
-                sendErrorMessage(session, "Message type is missing.");
+            if (actionType == null || actionType.trim().isEmpty()) {
+                sendErrorMessage(session, "Message type (subscribe/unsubscribe) is missing.");
                 return;
             }
 
-            switch (requestDto.getType().toLowerCase()) {
+            // stationId는 구독/구독해제 시 모두 필요
+            if (stationId == null || stationId.trim().isEmpty()) {
+                sendErrorMessage(session, "Station ID (arsId) is required.");
+                return;
+            }
+
+            switch (actionType.toLowerCase()) {
                 case "subscribe":
-                    handleSubscription(session, requestDto.getStationId());
+                    handleSubscription(session, stationId);
                     break;
                 case "unsubscribe":
-                    handleUnsubscription(session);
+                    handleUnsubscription(session, stationId); // stationId 전달
                     break;
                 default:
-                    sendErrorMessage(session, "Invalid message type: " + requestDto.getType() +
+                    sendErrorMessage(session, "Invalid message type: " + actionType +
                             ". Supported types are 'subscribe' or 'unsubscribe'.");
                     break;
             }
@@ -81,17 +96,18 @@ public class ArrivalBusInfoHandler extends TextWebSocketHandler {
     }
 
     private void handleSubscription(WebSocketSession session, String stationId) throws IOException {
-        if (stationId == null || stationId.trim().isEmpty()) {
-            sendErrorMessage(session, "Station ID (arsId) is required for subscription.");
-            return;
-        }
+        // stationSubscriptions 맵 업데이트
+        stationSubscriptions.computeIfAbsent(stationId, k -> new CopyOnWriteArraySet<>()).add(session);
 
-        // 기존 구독 정보가 있다면 제거 (다른 정류소로 변경 시)
-        String previousStationId = sessionStationMap.get(session);
-        if (previousStationId != null && !previousStationId.equals(stationId)) {
-            logger.info("Session {} changing subscription from {} to {}", session.getId(), previousStationId, stationId);
+        // sessionSubscriptions 맵 업데이트
+        Set<String> stationsForSession = sessionSubscriptions.get(session);
+        // afterConnectionEstablished에서 초기화되므로 null일 가능성은 낮지만 방어 코드
+        if (stationsForSession == null) {
+            stationsForSession = new CopyOnWriteArraySet<>();
+            sessionSubscriptions.put(session, stationsForSession);
         }
-        sessionStationMap.put(session, stationId);
+        stationsForSession.add(stationId);
+
         logger.info("Session {} subscribed to stationId: {}", session.getId(), stationId);
 
         // 구독 성공 응답 전송
@@ -105,37 +121,60 @@ public class ArrivalBusInfoHandler extends TextWebSocketHandler {
         sendInitialArrivalInfo(session, stationId);
     }
 
-    private void handleUnsubscription(WebSocketSession session) throws IOException {
-        String removedStationId = sessionStationMap.remove(session);
-        if (removedStationId != null) {
-            logger.info("Session {} unsubscribed from stationId: {}", session.getId(), removedStationId);
+    private void handleUnsubscription(WebSocketSession session, String stationId) throws IOException {
+        boolean removedFromStation = false;
+        Set<WebSocketSession> sessionsForStation = stationSubscriptions.get(stationId);
+        if (sessionsForStation != null) {
+            removedFromStation = sessionsForStation.remove(session);
+            if (sessionsForStation.isEmpty()) {
+                stationSubscriptions.remove(stationId); // 해당 정류소를 구독하는 세션이 없으면 맵에서 제거
+            }
+        }
+
+        boolean removedFromSession = false;
+        Set<String> stationsForSession = sessionSubscriptions.get(session);
+        if (stationsForSession != null) {
+            removedFromSession = stationsForSession.remove(stationId);
+            // 이 세션이 더 이상 아무것도 구독하지 않으면 sessionSubscriptions에서 제거할 수도 있음 (선택적)
+            // if (stationsForSession.isEmpty()) {
+            //     sessionSubscriptions.remove(session);
+            // }
+        }
+
+        if (removedFromStation || removedFromSession) {
+            logger.info("Session {} unsubscribed from stationId: {}", session.getId(), stationId);
             sendMessage(session, Map.of(
                     "type", "unsubscribe_success",
-                    "stationId", removedStationId,
-                    "message", "Successfully unsubscribed from station " + removedStationId + "."
+                    "stationId", stationId,
+                    "message", "Successfully unsubscribed from station " + stationId + "."
             ));
         } else {
-            logger.warn("Session {} tried to unsubscribe but was not subscribed.", session.getId());
-            sendErrorMessage(session, "You are not currently subscribed to any station.");
+            logger.warn("Session {} tried to unsubscribe from stationId {} but was not fully subscribed.", session.getId(), stationId);
+            sendErrorMessage(session, "You were not subscribed to station " + stationId + " or it was already removed.");
         }
     }
 
     // 특정 세션에 초기 도착 정보 전송
     private void sendInitialArrivalInfo(WebSocketSession session, String stationId) {
         try {
-            List<SpecificStationArrivalDto> arrivalInfo = busArrivalService.getArrivalsByStationId(stationId);
+            // BusArrivalCacheService를 사용하여 캐시에서 데이터 조회 (API 직접 호출 X)
+            List<SpecificStationArrivalDto> arrivalInfo = cacheService.getArrivalsForStation(stationId, false);
 
-            if (arrivalInfo != null && !arrivalInfo.isEmpty()) {
+            if (arrivalInfo == null) { // cacheService가 null을 반환할 경우 대비
+                arrivalInfo = Collections.emptyList();
+            }
+
+            if (!arrivalInfo.isEmpty()) {
                 sendMessage(session, Map.of(
-                        "type", "arrival_info",
+                        "type", "initial_arrival_info", // 메시지 타입 명확화
                         "stationId", stationId,
                         "data", arrivalInfo
                 ));
                 logger.info("Sent initial arrival info for stationId {} to session {}", stationId, session.getId());
             } else {
-                logger.info("No arrival info found for stationId {} or list is empty. Notifying client.", stationId);
+                logger.info("No initial arrival info found for stationId {} or list is empty. Notifying client.", stationId);
                 sendMessage(session, Map.of(
-                        "type", "no_arrival_info",
+                        "type", "no_initial_arrival_info", // 초기 정보 없음을 명확히
                         "stationId", stationId,
                         "message", "No arrival information currently available for station " + stationId + "."
                 ));
@@ -149,37 +188,44 @@ public class ArrivalBusInfoHandler extends TextWebSocketHandler {
 
     // 주기적으로 모든 구독자에게 업데이트된 정보를 보내는 메소드
     public void broadcastArrivalUpdates(String stationId, List<SpecificStationArrivalDto> arrivalInfo) {
-        if (arrivalInfo == null) { // 빈 리스트도 보낼 수 있도록 null 체크만
-            logger.debug("No updates (null list) to broadcast for stationId: {}", stationId);
-            return;
+        if (arrivalInfo == null) {
+            logger.debug("Received null arrivalInfo for stationId: {}. Broadcasting as empty.", stationId);
+            arrivalInfo = Collections.emptyList(); // null 대신 빈 리스트로 처리
         }
 
-        sessionStationMap.forEach((session, subscribedStationId) -> {
-            if (stationId.equals(subscribedStationId) && session.isOpen()) {
-                try {
-                    // 도착 정보가 비어있을 수도 있으므로, 그 경우에도 메시지를 보낼 수 있게 함
-                    if (arrivalInfo.isEmpty()) {
-                        sendMessage(session, Map.of(
-                                "type", "no_arrival_info", // 또는 "arrival_update_empty" 등
-                                "stationId", stationId,
-                                "message", "No arrival information currently available for station " + stationId + "."
-                        ));
-                        logger.info("Broadcasted empty arrival update for station {} to session {}", stationId, session.getId());
-                    } else {
-                        sendMessage(session, Map.of(
-                                "type", "arrival_info_update", // 초기 정보와 구분하기 위해 다른 type 사용 가능
-                                "stationId", stationId,
-                                "data", arrivalInfo
-                        ));
-                        logger.info("Broadcasted arrival update for station {} to session {}", stationId, session.getId());
+        Set<WebSocketSession> subscribedSessions = stationSubscriptions.get(stationId);
+        if (subscribedSessions != null && !subscribedSessions.isEmpty()) {
+            String type = arrivalInfo.isEmpty() ? "no_arrival_info_update" : "arrival_info_update";
+            String messageLog = arrivalInfo.isEmpty() ? "empty arrival update" : "arrival update";
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("type", type);
+            payload.put("stationId", stationId);
+
+            if (arrivalInfo.isEmpty()) {
+                payload.put("message", "No arrival information currently available for station " + stationId + ".");
+            } else {
+                payload.put("data", arrivalInfo);
+            }
+
+            for (WebSocketSession session : subscribedSessions) {
+                if (session.isOpen()) {
+                    try {
+                        sendMessage(session, payload);
+                        // 로그 레벨을 debug로 변경하여 너무 많은 로그 방지
+                        logger.debug("Broadcasted {} for station {} to session {}", messageLog, stationId, session.getId());
+                    } catch (Exception e) {
+                        logger.error("Error broadcasting message to session {}: {}", session.getId(), e.getMessage(), e);
+                        // 오류 발생 시 해당 세션 정리 고려 (주의: 반복자 내에서 컬렉션 수정 시 문제 발생 가능)
+                        // cleanupSession(session); // 직접 호출 시 동시성 문제 주의, 별도 처리 권장
                     }
-                } catch (Exception e) {
-                    logger.error("Error broadcasting message to session {}: {}", session.getId(), e.getMessage(), e);
-                    // 여기서 세션 제거 로직을 고려할 수 있지만, 동시성 문제에 주의해야 합니다.
-                    // sessionStationMap.remove(session); // 직접 제거 시 ConcurrentModificationException 발생 가능성
+                } else {
+                    // 세션이 닫혔으면 구독 목록에서 제거 (반복자 외부에서 처리하거나, 안전한 방식으로)
+                    // 이 부분은 afterConnectionClosed에서 주로 처리되지만, 여기서도 감지 가능
+                    logger.warn("Session {} for station {} was closed but still in subscription list during broadcast. Will be cleaned up.", session.getId(), stationId);
                 }
             }
-        });
+        }
     }
 
 
@@ -187,15 +233,32 @@ public class ArrivalBusInfoHandler extends TextWebSocketHandler {
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
         logger.error("WebSocket transport error for session {} (ID: {}): {}",
                 session.getRemoteAddress(), session.getId(), exception.getMessage(), exception);
-        // 전송 오류 발생 시, 해당 세션의 구독 정보를 제거하는 것이 안전할 수 있습니다.
-        sessionStationMap.remove(session);
+        cleanupSession(session); // 전송 오류 시 세션 정리
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        String removedStationId = sessionStationMap.remove(session);
-        logger.info("WebSocket connection closed: {} (ID: {}) - Status: {}. Unsubscribed from station: {}",
-                session.getRemoteAddress(), session.getId(), status, removedStationId != null ? removedStationId : "N/A");
+        logger.info("WebSocket connection closed: {} (ID: {}) - Status: {}",
+                session.getRemoteAddress(), session.getId(), status);
+        cleanupSession(session); // 연결 종료 시 세션 정리
+    }
+
+    // 세션과 관련된 모든 구독 정보 정리
+    private void cleanupSession(WebSocketSession session) {
+        Set<String> subscribedStationsForSession = sessionSubscriptions.remove(session);
+        if (subscribedStationsForSession != null) {
+            for (String stationId : subscribedStationsForSession) {
+                Set<WebSocketSession> sessionsForStation = stationSubscriptions.get(stationId);
+                if (sessionsForStation != null) {
+                    sessionsForStation.remove(session);
+                    if (sessionsForStation.isEmpty()) {
+                        stationSubscriptions.remove(stationId);
+                        logger.info("Removed stationId {} from subscriptions as no sessions are listening.", stationId);
+                    }
+                }
+            }
+        }
+        logger.info("Cleaned up all subscriptions for closed/error session: {}", session.getId());
     }
 
     // 클라이언트에게 메시지를 보내는 헬퍼 메소드 (JSON 변환 포함)
@@ -213,5 +276,14 @@ public class ArrivalBusInfoHandler extends TextWebSocketHandler {
     // 클라이언트에게 오류 메시지를 보내는 헬퍼 메소드
     private void sendErrorMessage(WebSocketSession session, String errorMessage) {
         sendMessage(session, Map.of("type", "error", "message", errorMessage));
+    }
+
+    /**
+     * 현재 구독 중인 모든 고유한 정류소 ID 목록을 반환합니다.
+     * @return 구독 중인 정류소 ID의 Set
+     */
+    public Set<String> getSubscribedStationIds() {
+        // stationSubscriptions의 키셋 자체가 현재 구독 중인 모든 고유한 정류소 ID 목록임
+        return Collections.unmodifiableSet(stationSubscriptions.keySet());
     }
 }

--- a/src/test/java/com/jhinslog/buswhich/service/BusArrivalCacheServiceTest.java
+++ b/src/test/java/com/jhinslog/buswhich/service/BusArrivalCacheServiceTest.java
@@ -1,0 +1,343 @@
+package com.jhinslog.buswhich.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jhinslog.buswhich.domain.cache.CachedStationArrival;
+import com.jhinslog.buswhich.dto.response.SpecificStationArrivalDto;
+import com.jhinslog.buswhich.repository.cache.CachedStationArrivalRepository;
+import com.jhinslog.buswhich.util.ApiOperation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class BusArrivalCacheServiceTest {
+
+    private static final ApiOperation TARGET_API_OPERATION = ApiOperation.GET_ARR_INFO_BY_ST_ID_LIST;
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        @Primary
+        public BusArrivalService seoulBusArrivalServiceImpl(BusArrivalCacheServiceTest testInstance) {
+            return testInstance.actualBusArrivalService;
+        }
+
+        @Bean
+        @Primary
+        public ApiCallManager apiCallManager(BusArrivalCacheServiceTest testInstance) {
+            return testInstance.apiCallManager;
+        }
+    }
+
+    @Autowired
+    private BusArrivalCacheService busArrivalCacheService;
+
+    @Autowired
+    private CachedStationArrivalRepository cacheRepository;
+
+    @Mock
+    private BusArrivalService actualBusArrivalService;
+
+    @Mock
+    private ApiCallManager apiCallManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String TEST_STATION_ID_1 = "STATION_001";
+
+    @BeforeEach
+    void setUp() {
+        cacheRepository.deleteAllInBatch();
+        // reset은 @MockBean으로 생성된 모의 객체에도 동일하게 사용할 수 있습니다.
+        reset(actualBusArrivalService, apiCallManager);
+    }
+
+    private SpecificStationArrivalDto createMockDto(String stationId, String routeName) {
+        SpecificStationArrivalDto dto = new SpecificStationArrivalDto();
+        dto.setStationId(stationId);
+        dto.setArsId(stationId);
+        dto.setStationName("테스트정류소-" + stationId);
+        dto.setRouteName(routeName);
+        dto.setFirstArrivalMsg("3분후[1번째 전]");
+        dto.setFirstCongestion("0");
+        dto.setDetourYn(false);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("캐시 히트: 유효한 캐시가 존재하면 API 호출 없이 캐시된 데이터를 반환한다")
+    void getArrivalsForStation_whenCacheHit_shouldReturnCachedDataWithoutApiCall() throws JsonProcessingException {
+        // given
+        List<SpecificStationArrivalDto> cachedDtos = List.of(createMockDto(TEST_STATION_ID_1, "100번"));
+        String jsonData = objectMapper.writeValueAsString(cachedDtos);
+        LocalDateTime expiryTime = LocalDateTime.now().plusMinutes(BusArrivalCacheService.CACHE_INTERNAL_TTL_MINUTES);
+        CachedStationArrival cacheEntry = new CachedStationArrival(TEST_STATION_ID_1, jsonData, LocalDateTime.now().minusMinutes(1), expiryTime);
+        cacheRepository.save(cacheEntry);
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getRouteName()).isEqualTo("100번");
+        verify(actualBusArrivalService, never()).getArrivalsByStationId(anyString());
+        verify(apiCallManager, never()).canMakeCall(any(ApiOperation.class));
+        verify(apiCallManager, never()).recordCall(any(ApiOperation.class));
+    }
+
+    @Test
+    @DisplayName("캐시 미스 (데이터 없음): 캐시가 없으면 API를 호출하고 결과를 캐시에 저장 후 반환한다")
+    void getArrivalsForStation_whenCacheMiss_shouldCallApiSaveToCacheAndReturnFreshData() {
+        // given
+        List<SpecificStationArrivalDto> freshDtosFromApi = List.of(createMockDto(TEST_STATION_ID_1, "200번"));
+        when(actualBusArrivalService.getArrivalsByStationId(TEST_STATION_ID_1)).thenReturn(freshDtosFromApi);
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(true); // API 호출 가능
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isEqualTo(freshDtosFromApi);
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, times(1)).getArrivalsByStationId(TEST_STATION_ID_1);
+        verify(apiCallManager, times(1)).recordCall(TARGET_API_OPERATION); // 호출 기록
+
+        Optional<CachedStationArrival> savedCache = cacheRepository.findByStationId(TEST_STATION_ID_1);
+        assertThat(savedCache).isPresent();
+        assertThat(savedCache.get().getArrivalDataJson()).isEqualToIgnoringWhitespace(serializeQuietly(freshDtosFromApi));
+        assertThat(savedCache.get().getCacheExpiryTime()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("캐시 만료: 캐시가 만료되었으면 API를 호출하고 캐시를 갱신 후 새 데이터를 반환한다")
+    void getArrivalsForStation_whenCacheExpired_shouldCallApiUpdateCacheAndReturnFreshData() throws JsonProcessingException {
+        // given
+        List<SpecificStationArrivalDto> expiredDtos = List.of(createMockDto(TEST_STATION_ID_1, "300번_만료됨"));
+        String expiredJsonData = objectMapper.writeValueAsString(expiredDtos);
+        LocalDateTime veryOldTime = LocalDateTime.now().minusHours(1);
+        CachedStationArrival expiredCacheEntry = new CachedStationArrival(TEST_STATION_ID_1, expiredJsonData, veryOldTime, veryOldTime.plusMinutes(1));
+        cacheRepository.save(expiredCacheEntry);
+
+        List<SpecificStationArrivalDto> freshDtosFromApi = List.of(createMockDto(TEST_STATION_ID_1, "300번_갱신됨"));
+        when(actualBusArrivalService.getArrivalsByStationId(TEST_STATION_ID_1)).thenReturn(freshDtosFromApi);
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(true);
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isEqualTo(freshDtosFromApi);
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, times(1)).getArrivalsByStationId(TEST_STATION_ID_1);
+        verify(apiCallManager, times(1)).recordCall(TARGET_API_OPERATION);
+
+        Optional<CachedStationArrival> updatedCache = cacheRepository.findByStationId(TEST_STATION_ID_1);
+        assertThat(updatedCache).isPresent();
+        assertThat(updatedCache.get().getArrivalDataJson()).isEqualToIgnoringWhitespace(serializeQuietly(freshDtosFromApi));
+        assertThat(updatedCache.get().getCacheExpiryTime()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("강제 새로고침: 캐시 유효성과 관계없이 API를 호출하고 캐시를 갱신 후 새 데이터를 반환한다")
+    void getArrivalsForStation_whenForceRefresh_shouldCallApiUpdateCacheAndReturnFreshData() throws JsonProcessingException {
+        // given
+        List<SpecificStationArrivalDto> existingCachedDtos = List.of(createMockDto(TEST_STATION_ID_1, "400번_기존캐시"));
+        String existingJsonData = objectMapper.writeValueAsString(existingCachedDtos);
+        LocalDateTime expiryTime = LocalDateTime.now().plusMinutes(BusArrivalCacheService.CACHE_INTERNAL_TTL_MINUTES);
+        CachedStationArrival cacheEntry = new CachedStationArrival(TEST_STATION_ID_1, existingJsonData, LocalDateTime.now().minusMinutes(1), expiryTime);
+        cacheRepository.save(cacheEntry);
+
+        List<SpecificStationArrivalDto> freshDtosFromApi = List.of(createMockDto(TEST_STATION_ID_1, "400번_강제갱신"));
+        when(actualBusArrivalService.getArrivalsByStationId(TEST_STATION_ID_1)).thenReturn(freshDtosFromApi);
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(true);
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, true);
+
+        // then
+        assertThat(result).isEqualTo(freshDtosFromApi);
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, times(1)).getArrivalsByStationId(TEST_STATION_ID_1);
+        verify(apiCallManager, times(1)).recordCall(TARGET_API_OPERATION);
+
+        Optional<CachedStationArrival> updatedCache = cacheRepository.findByStationId(TEST_STATION_ID_1);
+        assertThat(updatedCache).isPresent();
+        assertThat(updatedCache.get().getArrivalDataJson()).isEqualToIgnoringWhitespace(serializeQuietly(freshDtosFromApi));
+    }
+
+    @Test
+    @DisplayName("API 호출 실패: API 호출 중 예외 발생 시, 만료된 캐시라도 있으면 반환하고 호출 기록 안함")
+    void getArrivalsForStation_whenApiCallFails_shouldReturnStaleCacheIfExistsAndNotRecordCall() throws JsonProcessingException {
+        // given
+        List<SpecificStationArrivalDto> staleDtos = List.of(createMockDto(TEST_STATION_ID_1, "500번_오래됨"));
+        String staleJsonData = objectMapper.writeValueAsString(staleDtos);
+        LocalDateTime veryOldTime = LocalDateTime.now().minusHours(1);
+        CachedStationArrival staleCacheEntry = new CachedStationArrival(TEST_STATION_ID_1, staleJsonData, veryOldTime, veryOldTime.plusMinutes(1));
+        cacheRepository.save(staleCacheEntry);
+
+        when(actualBusArrivalService.getArrivalsByStationId(TEST_STATION_ID_1)).thenThrow(new RuntimeException("API 통신 오류!"));
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(true);
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isEqualTo(staleDtos);
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, times(1)).getArrivalsByStationId(TEST_STATION_ID_1);
+        verify(apiCallManager, never()).recordCall(TARGET_API_OPERATION); // API 실패 시 호출 기록 안 함
+    }
+
+    @Test
+    @DisplayName("API 호출 실패 (캐시 없음): API 호출 중 예외 발생하고 캐시도 없으면 빈 리스트 반환하고 호출 기록 안함")
+    void getArrivalsForStation_whenApiCallFailsAndNoCache_shouldReturnEmptyListAndNotRecordCall() {
+        // given
+        when(actualBusArrivalService.getArrivalsByStationId(TEST_STATION_ID_1)).thenThrow(new RuntimeException("API 통신 오류!"));
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(true);
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isNotNull().isEmpty();
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, times(1)).getArrivalsByStationId(TEST_STATION_ID_1);
+        verify(apiCallManager, never()).recordCall(TARGET_API_OPERATION);
+    }
+
+
+    @Test
+    @DisplayName("API가 null 반환: API가 null을 반환하면 빈 리스트를 반환하고 호출 기록은 한다")
+    void getArrivalsForStation_whenApiReturnsNull_shouldReturnEmptyListAndRecordCall() {
+        // given
+        when(actualBusArrivalService.getArrivalsByStationId(TEST_STATION_ID_1)).thenReturn(null); // API가 null 반환
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(true);
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isNotNull().isEmpty();
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, times(1)).getArrivalsByStationId(TEST_STATION_ID_1);
+        verify(apiCallManager, times(1)).recordCall(TARGET_API_OPERATION); // null 반환도 호출 성공으로 간주 (BusArrivalCacheService 로직에 따름)
+
+        Optional<CachedStationArrival> cacheEntry = cacheRepository.findByStationId(TEST_STATION_ID_1);
+        assertThat(cacheEntry).isNotPresent(); // null 데이터는 캐시하지 않음
+    }
+
+    @Test
+    @DisplayName("API 호출 제한 도달: API 호출 제한에 도달하면 API를 호출하지 않고, 유효한 캐시가 있으면 반환")
+    void getArrivalsForStation_whenApiLimitReachedAndValidCache_shouldReturnCachedDataWithoutApiCall() throws JsonProcessingException {
+        // given: 유효한 캐시 데이터 준비
+        List<SpecificStationArrivalDto> cachedDtos = List.of(createMockDto(TEST_STATION_ID_1, "600번_캐시있음"));
+        String jsonData = objectMapper.writeValueAsString(cachedDtos);
+        LocalDateTime expiryTime = LocalDateTime.now().plusMinutes(BusArrivalCacheService.CACHE_INTERNAL_TTL_MINUTES);
+        CachedStationArrival cacheEntry = new CachedStationArrival(TEST_STATION_ID_1, jsonData, LocalDateTime.now().minusMinutes(1), expiryTime);
+        cacheRepository.save(cacheEntry);
+
+        // when: 캐시 서비스를 호출 (강제 새로고침 아님)
+        // 이 경우, 캐시 히트 로직이 먼저 동작하므로 apiCallManager.canMakeCall은 호출되지 않음
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then: 캐시된 데이터 반환, API 호출 관련 메소드 호출 안됨
+        assertThat(result).isEqualTo(cachedDtos);
+        verify(apiCallManager, never()).canMakeCall(any(ApiOperation.class));
+        verify(actualBusArrivalService, never()).getArrivalsByStationId(anyString());
+        verify(apiCallManager, never()).recordCall(any(ApiOperation.class));
+    }
+
+
+    @Test
+    @DisplayName("API 호출 제한 도달 (캐시 만료): API 호출 제한 시 만료된 캐시라도 있으면 반환")
+    void getArrivalsForStation_whenApiLimitReachedAndCacheExpired_shouldReturnStaleCacheWithoutApiCall() throws JsonProcessingException {
+        // given: 만료된 캐시 데이터 준비
+        List<SpecificStationArrivalDto> staleDtos = List.of(createMockDto(TEST_STATION_ID_1, "700번_만료캐시"));
+        String staleJsonData = objectMapper.writeValueAsString(staleDtos);
+        LocalDateTime veryOldTime = LocalDateTime.now().minusHours(1);
+        CachedStationArrival staleCacheEntry = new CachedStationArrival(TEST_STATION_ID_1, staleJsonData, veryOldTime, veryOldTime.plusMinutes(1));
+        cacheRepository.save(staleCacheEntry);
+
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(false); // API 호출 제한!
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isEqualTo(staleDtos); // 만료된 캐시 반환
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION); // 호출 가능 여부 확인
+        verify(actualBusArrivalService, never()).getArrivalsByStationId(anyString()); // 실제 API 호출 안 함
+        verify(apiCallManager, never()).recordCall(any(ApiOperation.class)); // 호출 기록 안 함
+    }
+
+    @Test
+    @DisplayName("API 호출 제한 도달 (캐시 없음): API 호출 제한 시 캐시도 없으면 빈 리스트 반환")
+    void getArrivalsForStation_whenApiLimitReachedAndNoCache_shouldReturnEmptyListWithoutApiCall() {
+        // given: 캐시 없음
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(false); // API 호출 제한!
+
+        // when
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, false);
+
+        // then
+        assertThat(result).isNotNull().isEmpty(); // 빈 리스트 반환
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, never()).getArrivalsByStationId(anyString());
+        verify(apiCallManager, never()).recordCall(any(ApiOperation.class));
+    }
+
+    @Test
+    @DisplayName("API 호출 제한 도달 (강제 새로고침): 강제 새로고침 시에도 API 호출 제한이면 API 호출 안함 (만료 캐시 반환)")
+    void getArrivalsForStation_whenApiLimitReachedAndForceRefresh_shouldReturnStaleCacheWithoutApiCall() throws JsonProcessingException {
+        // given: 만료된 캐시 데이터 준비
+        List<SpecificStationArrivalDto> staleDtos = List.of(createMockDto(TEST_STATION_ID_1, "800번_만료캐시_강제"));
+        String staleJsonData = objectMapper.writeValueAsString(staleDtos);
+        LocalDateTime veryOldTime = LocalDateTime.now().minusHours(1);
+        CachedStationArrival staleCacheEntry = new CachedStationArrival(TEST_STATION_ID_1, staleJsonData, veryOldTime, veryOldTime.plusMinutes(1));
+        cacheRepository.save(staleCacheEntry);
+
+        when(apiCallManager.canMakeCall(TARGET_API_OPERATION)).thenReturn(false); // API 호출 제한!
+
+        // when: 강제 새로고침 true
+        List<SpecificStationArrivalDto> result = busArrivalCacheService.getArrivalsForStation(TEST_STATION_ID_1, true);
+
+        // then: 강제 새로고침이어도 API 호출 제한이면 API 호출 안하고 만료된 캐시 반환
+        assertThat(result).isEqualTo(staleDtos);
+        verify(apiCallManager, times(1)).canMakeCall(TARGET_API_OPERATION);
+        verify(actualBusArrivalService, never()).getArrivalsByStationId(anyString());
+        verify(apiCallManager, never()).recordCall(any(ApiOperation.class));
+    }
+
+
+    private String serializeQuietly(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error serializing object to JSON for test: " + value, e);
+        }
+    }
+}


### PR DESCRIPTION
주요 변경 사항:
- **BusArrivalCacheService 추가**:
  - 외부 API 응답 결과를 DB에 캐싱하여 반복적인 API 호출량을 감소.
  - 캐시 만료(TTL), 강제 갱신(force refresh) 로직을 구현.
  - API 호출 실패 시, 만료된 캐시(stale cache)라도 반환하여 서비스 안정성을 높힘.

- **ApiCallManager 추가**:
  - 기능별(ApiOperation) 일일 API 호출 횟수를 제한하여 과도한 호출을 방지.
  - @Scheduled를 이용해 매일 자정 호출 횟수를 자동으로 초기화.

- **리팩토링**:
  - API의 동작을 더 명확하게 표현하기 위해 `ApiFunctionName`에서 `ApiOperation`으로 변경.

- **단위 테스트**:
  - `BusArrivalCacheService`의 다양한 시나리오(캐시 히트, 미스, 만료, API 호출 제한 등)에 대한 단위 테스트 코드를 작성.
  - Mockito와 `@TestConfiguration`을 사용하여 의존성을 격리하고 테스트 환경을 구성.